### PR TITLE
Add unit tests for timer and prep logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-tests
 dist-ssr
 *.local
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "npm run test:build && node --test dist-tests/tests",
+    "test:build": "tsc --project tsconfig.test.json",
+    "test:watch": "tsc --project tsconfig.test.json --watch",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/lib/timer-utils.ts
+++ b/src/lib/timer-utils.ts
@@ -1,0 +1,111 @@
+import type { Ingredient } from "@/data/ingredients";
+import type { PrepItem, TimerItem } from "@/types";
+
+export function formatTimeLeft(ms: number): string {
+  const s = Math.max(0, Math.ceil(ms / 1000));
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return m > 0 ? `${m}:${r.toString().padStart(2, "0")}` : `${r}s`;
+}
+
+export function createTimerFromIngredient(
+  ing: Ingredient,
+  offsetSec = 0,
+  now: number = Date.now(),
+): TimerItem {
+  const totalMs = Math.max(0, (ing.seconds + offsetSec) * 1000);
+  return {
+    id: `${ing.id}_${now}`,
+    name: ing.name,
+    emoji: ing.emoji,
+    totalMs,
+    startAt: now,
+    endAt: now + totalMs,
+    status: "running",
+  };
+}
+
+export function calculatePercent(timer: TimerItem, now: number = Date.now()): number {
+  const total = timer.totalMs;
+  const passed = Math.min(total, Math.max(0, now - timer.startAt));
+  return total === 0 ? 100 : Math.round((passed / total) * 100);
+}
+
+export function completeDueTimers(
+  timers: TimerItem[],
+  now: number = Date.now(),
+): { updated: TimerItem[]; completedIds: string[] } {
+  const completedIds: string[] = [];
+  const updated = timers.map((timer) => {
+    if (timer.status === "running" && timer.endAt <= now) {
+      completedIds.push(timer.id);
+      return { ...timer, status: "done" as const };
+    }
+    return timer;
+  });
+  return { updated, completedIds };
+}
+
+export function createPrepItem(
+  ingredient: Ingredient,
+  now: number = Date.now(),
+): PrepItem {
+  return {
+    id: `prep_${ingredient.id}_${now}`,
+    ingredientId: ingredient.id,
+    name: ingredient.name,
+    emoji: ingredient.emoji || "🍽️",
+    seconds: ingredient.seconds,
+    addedAt: now,
+  };
+}
+
+export function addIngredientToPrepList(
+  prepList: PrepItem[],
+  ingredient: Ingredient,
+  now: number = Date.now(),
+): PrepItem[] {
+  if (prepList.some((item) => item.ingredientId === ingredient.id)) {
+    return prepList;
+  }
+  const newItem = createPrepItem(ingredient, now);
+  return [newItem, ...prepList];
+}
+
+export function updatePrepItemSeconds(
+  prepList: PrepItem[],
+  id: string,
+  customSeconds: number,
+  minimumSeconds = 15,
+): PrepItem[] {
+  const seconds = Math.max(minimumSeconds, customSeconds);
+  return prepList.map((item) =>
+    item.id === id
+      ? {
+          ...item,
+          customSeconds: seconds,
+        }
+      : item,
+  );
+}
+
+export function removePrepItem(prepList: PrepItem[], id: string): PrepItem[] {
+  return prepList.filter((item) => item.id !== id);
+}
+
+export function clearDoneTimers(timers: TimerItem[]): TimerItem[] {
+  return timers.filter((timer) => timer.status !== "done");
+}
+
+export function addTimerFromPrepItem(
+  timers: TimerItem[],
+  prepItem: PrepItem,
+  ingredientLookup: Map<string, Ingredient>,
+  now: number = Date.now(),
+): TimerItem[] {
+  const ingredient = ingredientLookup.get(prepItem.ingredientId);
+  if (!ingredient) return timers;
+  const customSeconds = prepItem.customSeconds ?? prepItem.seconds;
+  const timer = createTimerFromIngredient({ ...ingredient, seconds: customSeconds }, 0, now);
+  return [timer, ...timers];
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,23 @@
+export type TimerStatus = "running" | "paused" | "done";
+
+export interface TimerItem {
+  id: string;
+  name: string;
+  emoji?: string;
+  totalMs: number;
+  startAt: number;
+  endAt: number;
+  status: TimerStatus;
+  pausedLeftMs?: number;
+  note?: string;
+}
+
+export interface PrepItem {
+  id: string;
+  ingredientId: string;
+  name: string;
+  emoji: string;
+  seconds: number;
+  customSeconds?: number;
+  addedAt: number;
+}

--- a/tests/timer-utils.test.ts
+++ b/tests/timer-utils.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { INGREDIENTS } from "../src/data/ingredients.js";
+import type { PrepItem, TimerItem } from "../src/types.js";
+import {
+  addIngredientToPrepList,
+  addTimerFromPrepItem,
+  calculatePercent,
+  clearDoneTimers,
+  completeDueTimers,
+  createPrepItem,
+  createTimerFromIngredient,
+  formatTimeLeft,
+  removePrepItem,
+  updatePrepItemSeconds,
+} from "../src/lib/timer-utils.js";
+
+const SAMPLE_INGREDIENT = INGREDIENTS[0];
+
+describe("formatTimeLeft", () => {
+  it("formats seconds under one minute", () => {
+    assert.equal(formatTimeLeft(1500), "2s");
+  });
+
+  it("formats minutes and pads seconds", () => {
+    assert.equal(formatTimeLeft(125000), "2:05");
+  });
+});
+
+describe("createTimerFromIngredient", () => {
+  it("creates a running timer with offset", () => {
+    const now = 1_000;
+    const timer = createTimerFromIngredient(SAMPLE_INGREDIENT, 30, now);
+    assert.equal(timer.startAt, now);
+    assert.equal(timer.endAt, now + (SAMPLE_INGREDIENT.seconds + 30) * 1000);
+    assert.equal(timer.status, "running");
+    assert.equal(timer.totalMs, (SAMPLE_INGREDIENT.seconds + 30) * 1000);
+    assert.equal(timer.name, SAMPLE_INGREDIENT.name);
+  });
+});
+
+describe("calculatePercent", () => {
+  it("caps progress between 0 and 100", () => {
+    const base: TimerItem = {
+      id: "timer",
+      name: "Test",
+      totalMs: 10_000,
+      startAt: 0,
+      endAt: 10_000,
+      status: "running",
+    };
+
+    assert.equal(calculatePercent(base, 5_000), 50);
+    assert.equal(calculatePercent(base, -5_000), 0);
+    assert.equal(calculatePercent(base, 15_000), 100);
+  });
+});
+
+describe("completeDueTimers", () => {
+  it("marks only overdue running timers as done", () => {
+    const timers: TimerItem[] = [
+      {
+        id: "due",
+        name: "Due",
+        totalMs: 1000,
+        startAt: 0,
+        endAt: 500,
+        status: "running",
+      },
+      {
+        id: "future",
+        name: "Future",
+        totalMs: 1000,
+        startAt: 0,
+        endAt: 5000,
+        status: "running",
+      },
+      {
+        id: "done",
+        name: "Done",
+        totalMs: 1000,
+        startAt: 0,
+        endAt: 1000,
+        status: "done",
+      },
+    ];
+
+    const { updated, completedIds } = completeDueTimers(timers, 1000);
+    assert.deepEqual(completedIds, ["due"]);
+    const statuses = updated.map((t: TimerItem) => t.status);
+    assert.deepEqual(statuses, ["done", "running", "done"]);
+  });
+});
+
+describe("prep list helpers", () => {
+  it("creates a prep item with fallback emoji", () => {
+    const ingredient = { ...SAMPLE_INGREDIENT, emoji: undefined };
+    const now = 1234;
+    const item = createPrepItem(ingredient, now);
+    assert.equal(item.emoji, "🍽️");
+    assert.equal(item.id, `prep_${ingredient.id}_${now}`);
+  });
+
+  it("adds ingredient only once", () => {
+    const first = addIngredientToPrepList([], SAMPLE_INGREDIENT, 1);
+    const second = addIngredientToPrepList(first, SAMPLE_INGREDIENT, 2);
+    assert.equal(first.length, 1);
+    assert.equal(second.length, 1);
+    assert.equal(second[0].addedAt, first[0].addedAt);
+  });
+
+  it("updates prep seconds with minimum enforcement", () => {
+    const [item] = addIngredientToPrepList([], SAMPLE_INGREDIENT, 1);
+    const updated = updatePrepItemSeconds([item], item.id, 5, 10);
+    assert.equal(updated[0].customSeconds, 10);
+  });
+
+  it("removes prep item by id", () => {
+    const [item] = addIngredientToPrepList([], SAMPLE_INGREDIENT, 1);
+    const remaining = removePrepItem([item], item.id);
+    assert.equal(remaining.length, 0);
+  });
+});
+
+describe("addTimerFromPrepItem", () => {
+  it("adds timer with custom seconds at front of list", () => {
+    const [prepItem] = addIngredientToPrepList([], SAMPLE_INGREDIENT, 1);
+    const custom: PrepItem = { ...prepItem, customSeconds: prepItem.seconds + 30 };
+    const lookup = new Map(INGREDIENTS.map((ing: typeof INGREDIENTS[number]) => [ing.id, ing]));
+    const timers: TimerItem[] = [
+      {
+        id: "existing",
+        name: "Existing",
+        totalMs: 1000,
+        startAt: 0,
+        endAt: 1000,
+        status: "running",
+      },
+    ];
+
+    const result = addTimerFromPrepItem(timers, custom, lookup, 1000);
+    assert.equal(result.length, 2);
+    const [first] = result;
+    assert.equal(first.startAt, 1000);
+    assert.equal(first.totalMs, (prepItem.seconds + 30) * 1000);
+    assert.equal(first.name, SAMPLE_INGREDIENT.name);
+  });
+
+  it("ignores prep items without matching ingredient", () => {
+    const prepItem: PrepItem = {
+      id: "prep_missing",
+      ingredientId: "missing",
+      name: "Ghost",
+      emoji: "👻",
+      seconds: 60,
+      addedAt: 0,
+    };
+    const timers = addTimerFromPrepItem([], prepItem, new Map());
+    assert.equal(timers.length, 0);
+  });
+});
+
+describe("clearDoneTimers", () => {
+  it("filters completed timers", () => {
+    const timers: TimerItem[] = [
+      { id: "a", name: "A", totalMs: 1000, startAt: 0, endAt: 1000, status: "running" },
+      { id: "b", name: "B", totalMs: 1000, startAt: 0, endAt: 1000, status: "done" },
+    ];
+    const remaining = clearDoneTimers(timers);
+    assert.deepEqual(remaining.map((t: TimerItem) => t.id), ["a"]);
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist-tests",
+    "rootDir": ".",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["node"],
+    "noEmitOnError": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts", "types/**/*.d.ts"],
+  "exclude": ["node_modules", "dist", "dist-tests"]
+}

--- a/types/shims.d.ts
+++ b/types/shims.d.ts
@@ -1,0 +1,6 @@
+declare module "@radix-ui/react-tabs" {
+  export const Root: any;
+  export const List: any;
+  export const Trigger: any;
+  export const Content: any;
+}


### PR DESCRIPTION
## Summary
- extract timer and prep list helper logic into reusable utilities and shared types
- add a dedicated TypeScript build configuration and Node-based unit test runner
- cover formatting, timer completion, prep list management, and prep-to-timer flows with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68def45fe2fc8328810f3165546ea470